### PR TITLE
Fix Token Synchronization Issue Post Logout/Login

### DIFF
--- a/extranet/src/auth/useAxiosInterceptor.tsx
+++ b/extranet/src/auth/useAxiosInterceptor.tsx
@@ -3,16 +3,20 @@ import { useEffect } from 'react';
 
 export const useAxiosInterceptor = (refreshToken) => {
 	useEffect(() => {
-		const interceptor = axios.interceptors.response.use(
-			(response) => response, // If the response is successful, do nothing
+		// Request Interceptor
+		const requestInterceptor = axios.interceptors.request.use((request) => {
+			const currentToken = localStorage.getItem('token');
+			if (currentToken) {
+				request.headers['Authorization'] = `Bearer ${currentToken}`;
+			}
+			return request;
+		});
+
+		// Response Interceptor
+		const responseInterceptor = axios.interceptors.response.use(
+			(response) => response,
 			async (error) => {
-				// Only proceed if there's an error response and it's a 401
-				// That means the user is not authorized so the token needs to be refreshed
 				if (error.response && error.response.status === 401) {
-					// Exclude specific routes from triggering the refresh logic
-					// Because the token & refreshToken might be undefined when calling them
-					// e.g. login (after a logout and clean up of localStorage)
-					// e.g. refresh-token which means the currently stored token/refreshToken is invalid
 					const requestUrl = error.config.url;
 					const excludedEndpoints = [
 						'http://localhost:3000/api/auth/login',
@@ -21,26 +25,24 @@ export const useAxiosInterceptor = (refreshToken) => {
 
 					if (!excludedEndpoints.includes(requestUrl)) {
 						try {
-							await refreshToken(); // Attempt to refresh the token
-							// Update the Authorization header with the new token
+							await refreshToken();
 							error.config.headers[
 								'Authorization'
 							] = `Bearer ${localStorage.getItem('token')}`;
-							return axios(error.config); // Retry the original request with the new token
+							return axios(error.config);
 						} catch (refreshError) {
-							// If refreshing also fails, reject the promise
 							return Promise.reject(refreshError);
 						}
 					}
 				}
-				// If it's an excluded endpoint or not a 401, just reject the promise
 				return Promise.reject(error);
 			}
 		);
 
-		// Cleanup the interceptor when the component using this hook unmounts
+		// Cleanup
 		return () => {
-			axios.interceptors.response.eject(interceptor);
+			axios.interceptors.request.eject(requestInterceptor);
+			axios.interceptors.response.eject(responseInterceptor);
 		};
-	}, [refreshToken]); // Only recreate the interceptor when refreshToken changes
+	}, [refreshToken]);
 };


### PR DESCRIPTION
Solution:

- Implement an Axios request interceptor to attach the Authorization header with the current token from localStorage to every outgoing request.
- Update the Axios default headers after a successful login and logout to reflect the new token.
- Ensure proper cleanup of Axios interceptors to prevent memory leaks and unexpected behavior.