### PR TITLE
Restrict event creation to future dates

### DIFF
--- a/extranet/src/components/event/EventForm.tsx
+++ b/extranet/src/components/event/EventForm.tsx
@@ -184,6 +184,9 @@ const EventForm: React.FC = () => {
 									label='التاريخ'
 									type='date'
 									InputLabelProps={{ shrink: true }}
+									inputProps={{
+										min: new Date().toISOString().split('T')[0],
+									}}
 									error={Boolean(errors.date)}
 									helperText={errors.date?.message}
 								/>

--- a/src/controllers/event.js
+++ b/src/controllers/event.js
@@ -78,19 +78,29 @@ exports.createEvent = async (req) => {
 	}
 
 	const dateIso = new Date(date).toISOString().slice(0, 10);
+	const eventDate = new Date(dateIso);
+	const today = new Date();
+	today.setHours(0, 0, 0, 0);
+
+	// Prevent creating events in the past
+	if (eventDate < today) {
+		throw new ApiError(
+			'Cannot create events in the past. Please select a future date.',
+			STATUS_CODE.BAD_REQUEST,
+			['date']
+		);
+	}
+
 	const dateStr = dateIso.replace(/-/g, '');
-	const baseReference = `WEVENT${dateStr}`;
-	let reference = baseReference;
-	let suffix = 1;
-	while (await Event.exists({ reference })) {
-		reference = `${baseReference}-${String(suffix).padStart(2, '0')}`;
-		suffix += 1;
-		if (suffix > 99) {
-			throw new ApiError(
-				'Too many events for this date. Please choose another date.',
-				STATUS_CODE.CONFLICT
-			);
-		}
+	const reference = `WEVENT${dateStr}`;
+
+	// Check if an event already exists for this date
+	if (await Event.exists({ reference })) {
+		throw new ApiError(
+			'An event already exists for this date. Please choose a different date.',
+			STATUS_CODE.CONFLICT,
+			['date']
+		);
 	}
 
 	const frontend = process.env.FRONTEND_URL || 'http://localhost:3001';


### PR DESCRIPTION
Added frontend and backend validation to prevent creating events in the past. Also updated backend logic to allow only one event per date, returning a conflict error if an event already exists for the selected date.